### PR TITLE
Vertical scroll to the nearest parent element in Message-list components

### DIFF
--- a/lib/src/message-list/message-list.tsx
+++ b/lib/src/message-list/message-list.tsx
@@ -103,7 +103,7 @@ export const MessageList: FC<MessageListProps> = (props: MessageListProps) => {
 
   const scrollToBottom = () => {
     if (!endRef.current) return;
-    endRef.current.scrollIntoView();
+    endRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   };
 
   const setupSpinnerObserver = () => {


### PR DESCRIPTION
Hello, 

This is a change that allows to use the Message-list component within a page with other components. Basically, when the page scroll was activated (by the scrollIntoView function) then the component was put at the top of the page (not a problem in the sample app provided because the chat is in full window). 
With this modification, this will no longer be the case, so the scroll will just be in the scrollable parent div and the component will stay in its place.

Thanks for your time.