### PR TITLE
docs: explain setup for moderated-chat

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -71,19 +71,21 @@ apps for various use cases, with different functionalities and customizable look
    and test environments.
 
 3. Some of the functionalities you might want to enable on your keyset depending on the use-case
-   include _Presence_, _Storage & Playback_ (including correct Renention) and _Objects_ (be sure to
-   select a geographical region corresponding to most users of your application).
+   include _Presence_, _Files_, _Storage & Playback_ (including correct Retention Period) and _Objects_ (be sure to
+   select a geographical region corresponding to most users of your application).   The moderated-chat sample
+   *requires* these features are set in order to work with the
+   [moderation dashboard](https://github.com/pubnub/moderation-dashboard/blob/master/how-to-design-modertable-app.md).
 
 ## Run Sample Apps
 
-Start with exploring our [Sample Apps](https://pubnub.github.io/react-chat-components/samples) that
+Start by exploring our [Sample Apps](https://pubnub.github.io/react-chat-components/samples) that
 are built using chat components. Follow the steps below to run the apps locally in your own
 environment.
 
 1. Clone the repository:
 
 ```bash
-git clone git@github.com:pubnub/react-chat-components.git
+git clone https://github.com/pubnub/react-chat-components.git
 ```
 
 2. Go to the `samples` folder and install the dependencies:
@@ -101,7 +103,13 @@ npm install
 vi pubnub-keys.json
 ```
 
-4. Run the application:
+4. Pre-populate the User and Channel Object metadata (required only for the moderated-chat sample):
+
+```bash
+npm run setup
+```
+
+5. Run the application:
 
 ```bash
 npm start

--- a/lib/README.md
+++ b/lib/README.md
@@ -71,9 +71,10 @@ apps for various use cases, with different functionalities and customizable look
    and test environments.
 
 3. Some of the functionalities you might want to enable on your keyset depending on the use-case
-   include _Presence_, _Files_, _Storage & Playback_ (including correct Retention Period) and _Objects_ (be sure to
-   select a geographical region corresponding to most users of your application).   The moderated-chat sample
-   *requires* these features are set in order to work with the
+   include _Presence_, _Files_, _Storage & Playback_ (including correct Retention Period) and
+   _Objects_ (be sure to select a geographical region corresponding to most users of your
+   application). The moderated-chat sample _requires_ these features are set in order to work with
+   the
    [moderation dashboard](https://github.com/pubnub/moderation-dashboard/blob/master/how-to-design-modertable-app.md).
 
 ## Run Sample Apps
@@ -88,14 +89,19 @@ environment.
 git clone https://github.com/pubnub/react-chat-components.git
 ```
 
-2. Go to the `samples` folder and install the dependencies:
+2. Go to the `samples` folder:
 
 ```bash
 cd react-chat-components/samples
+```
+
+3. Install the dependencies:
+
+```bash
 npm install
 ```
 
-3. Follow steps from the
+4. Follow steps from the
    [PubNub Account section](https://github.com/pubnub/react-chat-components/blob/master/lib/README.md#pubnub-account)
    to create your own keys and paste them into `pubnub-keys.json`:
 
@@ -103,13 +109,13 @@ npm install
 vi pubnub-keys.json
 ```
 
-4. Pre-populate the User and Channel Object metadata (required only for the moderated-chat sample):
+5. Pre-populate the User and Channel Object metadata (required only for the moderated-chat sample):
 
 ```bash
 npm run setup
 ```
 
-5. Run the application:
+6. Run the application:
 
 ```bash
 npm start

--- a/samples/package.json
+++ b/samples/package.json
@@ -36,6 +36,7 @@
     "yargs": "^17.1.1"
   },
   "scripts": {
+    "setup": "cd src/moderated-chat; node populate-pn-objects.js; cd ../..",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",

--- a/samples/package.json
+++ b/samples/package.json
@@ -36,7 +36,7 @@
     "yargs": "^17.1.1"
   },
   "scripts": {
-    "setup": "cd src/moderated-chat; node populate-pn-objects.js; cd ../..",
+    "setup": "node populate-pn-objects.js",
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",

--- a/samples/populate-pn-objects.js
+++ b/samples/populate-pn-objects.js
@@ -6,8 +6,8 @@ const yargs = require("yargs/yargs");
 const { hideBin } = require("yargs/helpers");
 const sampleSize = require("lodash.sampleSize");
 
-const users = require("../../../data/users.json");
-const channels = require("../../../data/channels-work.json");
+const users = require("../data/users.json");
+const channels = require("../data/channels-work.json");
 
 /**
  * This version of the population script adds:
@@ -40,7 +40,7 @@ const sleep = async (ms) => {
 };
 
 const getKeys = async () => {
-  const text = await fs.readFileSync("../../pubnub-keys.json", "utf-8");
+  const text = await fs.readFileSync("pubnub-keys.json", "utf-8");
   return JSON.parse(text);
 };
 


### PR DESCRIPTION
Document that the moderated-chat requires keyset configurations and a script that pre-populates the user, channel, and membership metadata.