### PR TITLE
feat(samples): add PN interactive demo framework to live-events sample

### DIFF
--- a/samples/live-events/package.json
+++ b/samples/live-events/package.json
@@ -11,6 +11,7 @@
     "@pubnub/react-chat-components": "^0.10.0",
     "emoji-mart": "^3.0.0",
     "pubnub": "^4.36.0",
+    "pubnub-demo-integration": "^0.1.0",
     "pubnub-react": "^2.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/samples/live-events/public/features.json
+++ b/samples/live-events/public/features.json
@@ -1,10 +1,10 @@
 {
-    "features": [
-      "Send Text Message",
-      "Send a Message with an Emoji",
-      "Be in a Channel with 2 or More People",
-      "View Channel Participants",
-      "Switch to a Different Channel",
-      "Switch to Light Mode"
-    ]
+  "features": [
+    "Send Text Message",
+    "Send a Message with an Emoji",
+    "Be in a Channel with 2 or More People",
+    "View Channel Participants",
+    "Switch to a Different Channel",
+    "Switch to Light Mode"
+  ]
 }

--- a/samples/live-events/public/features.json
+++ b/samples/live-events/public/features.json
@@ -1,0 +1,10 @@
+{
+    "features": [
+      "Send Text Message",
+      "Send a Message with an Emoji",
+      "Be in a Channel with 2 or More People",
+      "View Channel Participants",
+      "Switch to a Different Channel",
+      "Switch to Light Mode"
+    ]
+}

--- a/samples/live-events/src/components/ChannelsView.tsx
+++ b/samples/live-events/src/components/ChannelsView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from "react";
 import { usePubNub } from "pubnub-react";
+import { actionCompleted } from "pubnub-demo-integration";
 import useClickAway from "react-use/lib/useClickAway";
 import {
   ChannelEntity,
@@ -14,8 +15,6 @@ import { ReactComponent as ExpandIcon } from "../assets/expand.svg";
 import { ReactComponent as EllipsisIcon } from "../assets/ellipsis-vertical.svg";
 import { ReactComponent as MoonIcon } from "../assets/moon-over-sun.svg";
 import { ReactComponent as QuestionIcon } from "../assets/question-check.svg";
-
-import {actionCompleted} from "pubnub-demo-integration";
 
 type ChannelsViewProps = {
   channels: ChannelEntity[];
@@ -116,7 +115,7 @@ const ChannelsView = (props: ChannelsViewProps): JSX.Element => {
                 setDarkMode(!darkMode);
                 setShowUserMenu(false);
                 if (darkMode)
-                  actionCompleted({action: "Switch to Light Mode", blockDuplicateCalls:true, debug:false});
+                  actionCompleted({ action: "Switch to Light Mode", blockDuplicateCalls: true });
               }}
             >
               <MoonIcon className="mr-3 w-6" />

--- a/samples/live-events/src/components/ChannelsView.tsx
+++ b/samples/live-events/src/components/ChannelsView.tsx
@@ -15,6 +15,8 @@ import { ReactComponent as EllipsisIcon } from "../assets/ellipsis-vertical.svg"
 import { ReactComponent as MoonIcon } from "../assets/moon-over-sun.svg";
 import { ReactComponent as QuestionIcon } from "../assets/question-check.svg";
 
+import {actionCompleted} from "pubnub-demo-integration";
+
 type ChannelsViewProps = {
   channels: ChannelEntity[];
   channelsExpanded: boolean;
@@ -113,6 +115,8 @@ const ChannelsView = (props: ChannelsViewProps): JSX.Element => {
               onClick={() => {
                 setDarkMode(!darkMode);
                 setShowUserMenu(false);
+                if (darkMode)
+                  actionCompleted({action: "Switch to Light Mode", blockDuplicateCalls:true, debug:false});
               }}
             >
               <MoonIcon className="mr-3 w-6" />

--- a/samples/live-events/src/components/ChatView.tsx
+++ b/samples/live-events/src/components/ChatView.tsx
@@ -1,13 +1,18 @@
 import React, { useState } from "react";
 import { Picker } from "emoji-mart";
-import { MessageList, MessageInput, MemberList } from "@pubnub/react-chat-components";
+import { actionCompleted, containsEmoji } from "pubnub-demo-integration";
+import {
+  MessageList,
+  MessageInput,
+  MemberList,
+  StandardMessage,
+} from "@pubnub/react-chat-components";
 
 import { ReactComponent as ExpandIcon } from "../assets/expand.svg";
 import { ReactComponent as ChatIcon } from "../assets/chat.svg";
 import { ReactComponent as GroupIcon } from "../assets/user-group.svg";
 import { ReactComponent as ArrowIcon } from "../assets/arrow-turn-up.svg";
 import "emoji-mart/css/emoji-mart.css";
-import {actionCompleted, containsEmoji} from "pubnub-demo-integration";
 
 type ChatViewProps = {
   channelOccupants: { uuid: string }[];
@@ -25,17 +30,13 @@ const ChatView = ({
   const members = channelOccupants?.map((o) => o.uuid);
   const [showMembers, setShowMembers] = useState(false);
 
-  function demoSendMessage(value: any)
-  {
-      if (value.type === "text")
-      {
-        if (containsEmoji({testString: value.text, debug:false}))
-          actionCompleted({action: "Send a Message with an Emoji", blockDuplicateCalls:true, debug:false});
-        else
-          actionCompleted({action: "Send Text Message", blockDuplicateCalls:true, debug:false});
-      }
-      
-  }
+  const demoSendMessage = (value: StandardMessage) => {
+    if (value.type === "text") {
+      if (containsEmoji({ testString: value.text }))
+        actionCompleted({ action: "Send a Message with an Emoji", blockDuplicateCalls: true });
+      else actionCompleted({ action: "Send Text Message", blockDuplicateCalls: true });
+    }
+  };
 
   return (
     <aside
@@ -61,8 +62,8 @@ const ChatView = ({
           className={`p-2 ${!chatExpanded && "hidden"}`}
           onClick={() => {
             setShowMembers(!showMembers);
-            if(!showMembers)
-              actionCompleted({action: "View Channel Participants", blockDuplicateCalls: true, debug: false});
+            if (!showMembers)
+              actionCompleted({ action: "View Channel Participants", blockDuplicateCalls: true });
           }}
         >
           {showMembers ? <ChatIcon /> : <GroupIcon />}

--- a/samples/live-events/src/components/ChatView.tsx
+++ b/samples/live-events/src/components/ChatView.tsx
@@ -30,7 +30,7 @@ const ChatView = ({
   const members = channelOccupants?.map((o) => o.uuid);
   const [showMembers, setShowMembers] = useState(false);
 
-  const completeDemoAction = (message: MessagePayload) => {
+  const completeDemoAction = (message: MessagePayload | File) => {
     if (message.type === "default") {
       if (containsEmoji({ testString: message.text }))
         actionCompleted({ action: "Send a Message with an Emoji", blockDuplicateCalls: true });

--- a/samples/live-events/src/components/ChatView.tsx
+++ b/samples/live-events/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import { ReactComponent as ChatIcon } from "../assets/chat.svg";
 import { ReactComponent as GroupIcon } from "../assets/user-group.svg";
 import { ReactComponent as ArrowIcon } from "../assets/arrow-turn-up.svg";
 import "emoji-mart/css/emoji-mart.css";
+import {actionCompleted, containsEmoji} from "pubnub-demo-integration";
 
 type ChatViewProps = {
   channelOccupants: { uuid: string }[];
@@ -23,6 +24,18 @@ const ChatView = ({
 }: ChatViewProps): JSX.Element => {
   const members = channelOccupants?.map((o) => o.uuid);
   const [showMembers, setShowMembers] = useState(false);
+
+  function demoSendMessage(value: any)
+  {
+      if (value.type === "text")
+      {
+        if (containsEmoji({testString: value.text, debug:false}))
+          actionCompleted({action: "Send a Message with an Emoji", blockDuplicateCalls:true, debug:false});
+        else
+          actionCompleted({action: "Send Text Message", blockDuplicateCalls:true, debug:false});
+      }
+      
+  }
 
   return (
     <aside
@@ -46,7 +59,11 @@ const ChatView = ({
         </h4>
         <button
           className={`p-2 ${!chatExpanded && "hidden"}`}
-          onClick={() => setShowMembers(!showMembers)}
+          onClick={() => {
+            setShowMembers(!showMembers);
+            if(!showMembers)
+              actionCompleted({action: "View Channel Participants", blockDuplicateCalls: true, debug: false});
+          }}
         >
           {showMembers ? <ChatIcon /> : <GroupIcon />}
         </button>
@@ -67,6 +84,7 @@ const ChatView = ({
                   <ArrowIcon />
                 </span>
               }
+              onSend={(value) => demoSendMessage(value)}
             />
           </>
         )}

--- a/samples/live-events/src/components/ChatView.tsx
+++ b/samples/live-events/src/components/ChatView.tsx
@@ -5,7 +5,7 @@ import {
   MessageList,
   MessageInput,
   MemberList,
-  StandardMessage,
+  MessagePayload,
 } from "@pubnub/react-chat-components";
 
 import { ReactComponent as ExpandIcon } from "../assets/expand.svg";
@@ -30,9 +30,9 @@ const ChatView = ({
   const members = channelOccupants?.map((o) => o.uuid);
   const [showMembers, setShowMembers] = useState(false);
 
-  const demoSendMessage = (value: StandardMessage) => {
-    if (value.type === "text") {
-      if (containsEmoji({ testString: value.text }))
+  const completeDemoAction = (message: MessagePayload) => {
+    if (message.type === "default") {
+      if (containsEmoji({ testString: message.text }))
         actionCompleted({ action: "Send a Message with an Emoji", blockDuplicateCalls: true });
       else actionCompleted({ action: "Send Text Message", blockDuplicateCalls: true });
     }
@@ -85,7 +85,7 @@ const ChatView = ({
                   <ArrowIcon />
                 </span>
               }
-              onSend={(value) => demoSendMessage(value)}
+              onSend={completeDemoAction}
             />
           </>
         )}

--- a/samples/live-events/src/index.tsx
+++ b/samples/live-events/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import PubNub from "pubnub";
 import { PubNubProvider } from "pubnub-react";
 import faker from "@faker-js/faker";
+import { actionCompleted } from "pubnub-demo-integration";
 import { ChannelEntity, Chat, usePresence } from "@pubnub/react-chat-components";
 import useWindowSize from "react-use/lib/useWindowSize";
 import usePrevious from "react-use/lib/usePrevious";
@@ -15,8 +16,6 @@ import "./index.css";
 
 const mdBreakpoint = 768;
 const lgBreakpoint = 1024;
-
-import {actionCompleted} from "pubnub-demo-integration";
 
 const pubnub = new PubNub({
   publishKey: (import.meta.env?.REACT_APP_PUB_KEY as string) || "",
@@ -57,15 +56,21 @@ const LiveEventChat = (): JSX.Element => {
 
   useEffect(() => {
     if (channelOccupancy && channelOccupancy > 1) {
-      actionCompleted({action: "Be in a Channel with 2 or More People", blockDuplicateCalls: true, debug: false});
-    } 
-  }, [channelOccupancy])
+      actionCompleted({
+        action: "Be in a Channel with 2 or More People",
+        blockDuplicateCalls: true,
+      });
+    }
+  }, [channelOccupancy]);
 
   useEffect(() => {
     if (currentChannel != channels[0]) {
-      actionCompleted({action: "Switch to a Different Channel", blockDuplicateCalls: true, debug: false});
-    } 
-  }, [currentChannel])
+      actionCompleted({
+        action: "Switch to a Different Channel",
+        blockDuplicateCalls: true,
+      });
+    }
+  }, [currentChannel]);
 
   return (
     <main className={`flex ${darkMode ? "dark" : "light"}`}>

--- a/samples/live-events/src/index.tsx
+++ b/samples/live-events/src/index.tsx
@@ -16,6 +16,8 @@ import "./index.css";
 const mdBreakpoint = 768;
 const lgBreakpoint = 1024;
 
+import {actionCompleted} from "pubnub-demo-integration";
+
 const pubnub = new PubNub({
   publishKey: (import.meta.env?.REACT_APP_PUB_KEY as string) || "",
   subscribeKey: (import.meta.env?.REACT_APP_SUB_KEY as string) || "",
@@ -52,6 +54,18 @@ const LiveEventChat = (): JSX.Element => {
     if (!prevChannelsExpanded) setChatExpanded(false);
     if (!prevChatExpanded) setChannelsExpanded(false);
   }, [width, chatExpanded, prevChatExpanded, channelsExpanded, prevChannelsExpanded]);
+
+  useEffect(() => {
+    if (channelOccupancy && channelOccupancy > 1) {
+      actionCompleted({action: "Be in a Channel with 2 or More People", blockDuplicateCalls: true, debug: false});
+    } 
+  }, [channelOccupancy])
+
+  useEffect(() => {
+    if (currentChannel != channels[0]) {
+      actionCompleted({action: "Switch to a Different Channel", blockDuplicateCalls: true, debug: false});
+    } 
+  }, [currentChannel])
 
   return (
     <main className={`flex ${darkMode ? "dark" : "light"}`}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,6 +5627,11 @@ data-uri-to-buffer@3:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -6837,6 +6842,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
+  integrity sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -7045,6 +7058,13 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 formidable@^1.2.2:
   version "1.2.6"
@@ -9918,12 +9938,26 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.6.tgz#6d4627181697a9d9674aae0d61548e0d629b31b9"
+  integrity sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -11262,6 +11296,13 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
+
+pubnub-demo-integration@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/pubnub-demo-integration/-/pubnub-demo-integration-0.1.0.tgz#fec317163c777a133014634612bc17b5a4998b80"
+  integrity sha512-V3Z/wTtpECBQCQA5gHCQsmgLJ4bl4lRMxkXfPbhEwR7AGct7IZjy9duqszlhWbqg1x4YjlI4SkEoIUj20iVEMw==
+  dependencies:
+    node-fetch "^3.2.6"
 
 pubnub-react@^2.1.0, pubnub-react@^2.1.1:
   version "2.1.1"
@@ -13940,6 +13981,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
@Salet as discussed on IM, these are changes designed to allow the virtual events demo to work within the interactive demo framework - it will look something like this: https://deploy-preview-239--pubnub-modular.netlify.app/demo/virtual-events/