### PR TITLE
docs: add code examples about user metadata

### DIFF
--- a/lib/docs/preview.js
+++ b/lib/docs/preview.js
@@ -70,7 +70,7 @@ export const parameters = {
         "UI Theming",
         ["Themes", "CSS Variables", "Custom Renderers", "Examples"],
         "Code Examples",
-        ["Basic", "Customization"],
+        ["User metadata", "Customization"],
       ],
     },
   },

--- a/lib/docs/preview.js
+++ b/lib/docs/preview.js
@@ -70,7 +70,7 @@ export const parameters = {
         "UI Theming",
         ["Themes", "CSS Variables", "Custom Renderers", "Examples"],
         "Code Examples",
-        ["Customization"],
+        ["Basic", "Customization"],
       ],
     },
   },

--- a/lib/docs/stories/code-examples/basic.stories.mdx
+++ b/lib/docs/stories/code-examples/basic.stories.mdx
@@ -1,0 +1,82 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Code Examples/Basic" />
+
+# Basic examples
+
+<br />
+<br />
+
+## Ensuring components display user metadata
+
+Chat Components require you to explicitly pass information about the users of your app, in order to
+correctly display their names and avatars. Otherwise, messages will show sender IDs and avatar
+placeholders. The metadata can be provided from numerous different sources, including your own
+database or PubNub Objects storage. You can also attach information about the sender directly to
+each message.
+
+<br />
+
+### Passing in metadata for all users previously stored in PubNub Objects
+
+```jsx
+import PubNub from "pubnub";
+import { PubNubProvider } from "pubnub-react";
+import { Chat, MessageList, MessageInput, useUsers } from "@pubnub/react-chat-components";
+
+const pubnub = new PubNub({
+  publishKey: "demo",
+  subscribeKey: "demo",
+  uuid: "test-user",
+});
+
+export default function PubNubChat() {
+  return (
+    <PubNubProvider client={pubnub}>
+      <ChatConversation />
+    </PubNubProvider>
+  );
+}
+
+export function ChatConversation() {
+  const [users] = useUsers();
+
+  return (
+    <Chat currentChannel="test-channel" users={users}>
+      <MessageList />
+      <MessageInput />
+    </Chat>
+  );
+}
+```
+
+### Attaching sender metadata to each message
+
+```jsx
+import PubNub from "pubnub";
+import { PubNubProvider } from "pubnub-react";
+import { Chat, MessageList, MessageInput } from "@pubnub/react-chat-components";
+
+const myUser = {
+  id: "test-user",
+  name: "Mark Kelley",
+  profileUrl: "https://randomuser.me/api/portraits/men/1.jpg",
+};
+
+const pubnub = new PubNub({
+  publishKey: "demo",
+  subscribeKey: "demo",
+  uuid: myUser.id,
+});
+
+export default function PubNubChat() {
+  return (
+    <PubNubProvider client={pubnub}>
+      <Chat currentChannel="test-channel" users={[myUser]}>
+        <MessageList />
+        <MessageInput senderInfo={true} />
+      </Chat>
+    </PubNubProvider>
+  );
+}
+```

--- a/lib/docs/stories/code-examples/user-metadata.stories.mdx
+++ b/lib/docs/stories/code-examples/user-metadata.stories.mdx
@@ -6,19 +6,19 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 PubNub Chat Components for React require you to explicitly pass information about the users of your
 app to correctly display their names and avatars. Otherwise, messages will show sender IDs and
-avatar placeholders. The metadata can be provided from numerous different sources, including your
-own database or PubNub Objects storage. You can also attach information about the sender directly to
+avatar placeholders. You can provide metadata from numerous different sources, including your own
+database or PubNub Objects storage. You can also attach information about the sender directly to
 each message.
 
 <br />
 
 ## Pass in metadata of all users
 
-This example assumes user information was previously stored into
-[PubNub Objects](https://www.pubnub.com/docs/metadata/users-metadata). In that case you can easily
-fetch it using
+This example assumes user information was previously stored in
+[PubNub Objects](https://www.pubnub.com/docs/metadata/users-metadata). In that case, you can easily
+fetch it using the
 [useUsers](https://pubnub.github.io/react-chat-components/docs/?path=/docs/custom-hooks-useusers--page)
-custom hook and pass all of it directly to the components using `users` option in the `Chat`
+custom hook and pass all of it directly to the components using the `users` option in the `Chat`
 provider:
 
 ```jsx
@@ -54,9 +54,9 @@ export function ChatConversation() {
 
 ## Attach sender data to messages
 
-Alternatively, you can provide the info on just your current user and attach id directly to each
-message using `senderInfo` option in the `MessageInput`. In this case you can still use PubNub to
-store this information, but let's see how would that work with dynamically created data:
+Alternatively, you can just provide the information on your current user and attach its ID directly
+to each message using the `senderInfo` option in the `MessageInput`. In this case, you can still use
+PubNub to store this information, but that's how it would work with dynamically created data:
 
 ```jsx
 import PubNub from "pubnub";

--- a/lib/docs/stories/code-examples/user-metadata.stories.mdx
+++ b/lib/docs/stories/code-examples/user-metadata.stories.mdx
@@ -1,23 +1,25 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Code Examples/Basic" />
+<Meta title="Code Examples/User metadata" />
 
-# Basic examples
+# User metadata
 
-<br />
-<br />
-
-## Ensuring components display user metadata
-
-Chat Components require you to explicitly pass information about the users of your app, in order to
-correctly display their names and avatars. Otherwise, messages will show sender IDs and avatar
-placeholders. The metadata can be provided from numerous different sources, including your own
-database or PubNub Objects storage. You can also attach information about the sender directly to
+PubNub Chat Components for React require you to explicitly pass information about the users of your
+app to correctly display their names and avatars. Otherwise, messages will show sender IDs and
+avatar placeholders. The metadata can be provided from numerous different sources, including your
+own database or PubNub Objects storage. You can also attach information about the sender directly to
 each message.
 
 <br />
 
-### Passing in metadata for all users previously stored in PubNub Objects
+## Pass in metadata of all users
+
+This example assumes user information was previously stored into
+[PubNub Objects](https://www.pubnub.com/docs/metadata/users-metadata). In that case you can easily
+fetch it using
+[useUsers](https://pubnub.github.io/react-chat-components/docs/?path=/docs/custom-hooks-useusers--page)
+custom hook and pass all of it directly to the components using `users` option in the `Chat`
+provider:
 
 ```jsx
 import PubNub from "pubnub";
@@ -50,7 +52,11 @@ export function ChatConversation() {
 }
 ```
 
-### Attaching sender metadata to each message
+## Attach sender data to messages
+
+Alternatively, you can provide the info on just your current user and attach id directly to each
+message using `senderInfo` option in the `MessageInput`. In this case you can still use PubNub to
+store this information, but let's see how would that work with dynamically created data:
 
 ```jsx
 import PubNub from "pubnub";

--- a/lib/docs/stories/introduction/metadata.stories.mdx
+++ b/lib/docs/stories/introduction/metadata.stories.mdx
@@ -8,12 +8,12 @@ Some components require providing lists of channels and users that should be dis
 those work fine with simple lists of `strings`, although look much better when provided with
 metadata about the entities. See the reference below to understand what's expected where and why:
 
-| Component         | Description                                                                                                           | Property                       | Data type (see below)           |
-| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :----------------------------- | ------------------------------- |
-| `ChannelList`     | Displays channel names with descriptions.                                                                             | `channels`                     | `string[]` or `ChannelEntity[]` |
-| `MemberList`      | Displays full user names, avatars and an additional line of text that can serve as a user's description/title/status. | `members`                      | `string[]` or `UserEntity[]`    |
-| `MessageList`     | Displays full user names and avatars.                                                                                 | `users` of the `Chat` provider | `UserEntity[]`                  |
-| `TypingIndicator` | Displays full user names or avatars, depending on the type of the indicator.                                          | `users` of the `Chat` provider | `UserEntity[]`                  |
+| Component         | Description                                                                                                           | Property                                                                                                                            | Data type (see below)           |
+| :---------------- | :-------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `ChannelList`     | Displays channel names with descriptions.                                                                             | `channels`                                                                                                                          | `string[]` or `ChannelEntity[]` |
+| `MemberList`      | Displays full user names, avatars and an additional line of text that can serve as a user's description/title/status. | `members`                                                                                                                           | `string[]` or `UserEntity[]`    |
+| `MessageList`     | Displays full user names and avatars.                                                                                 | [`users` of the `Chat` provider](https://pubnub.github.io/react-chat-components/docs/?path=/docs/code-examples-user-metadata--page) | `UserEntity[]`                  |
+| `TypingIndicator` | Displays full user names or avatars, depending on the type of the indicator.                                          | [`users` of the `Chat` provider](https://pubnub.github.io/react-chat-components/docs/?path=/docs/code-examples-user-metadata--page) | `UserEntity[]`                  |
 
 ## Data source
 


### PR DESCRIPTION
This adds some code examples to our docs explaining how to pass user metadata into components. Hopefully this will limit the number of support tickets like this: https://pubnub.zendesk.com/agent/tickets/43629
