### PR TITLE
Change uuid to userId

### DIFF
--- a/lib/docs/stories/introduction/usage.stories.mdx
+++ b/lib/docs/stories/introduction/usage.stories.mdx
@@ -106,8 +106,7 @@ npm install
 5. Open the app in the code editor, navigate to the `src/getting-started.tsx` file and replace
    `myPublishKey` and `mySubscribeKey` with your own Publish and Subscribe Keys from the keyset on
    the Admin Portal. To associate a sender/current user with the PubNub messages, it's required to
-   configure [UUID](/docs/setup/users-and-devices) (the `userId` parameter) that stands for Universally Unique Identifier and refers to your user ID in the database. If you wish, modify
-   the default value for the chat user.
+   configure the `userId` parameter (also known as [UUID](/docs/setup/users-and-devices)) to define the default value for the chat user.
 
 ```jsx
 publishKey: "myPublishKey",

--- a/lib/docs/stories/introduction/usage.stories.mdx
+++ b/lib/docs/stories/introduction/usage.stories.mdx
@@ -106,14 +106,13 @@ npm install
 5. Open the app in the code editor, navigate to the `src/getting-started.tsx` file and replace
    `myPublishKey` and `mySubscribeKey` with your own Publish and Subscribe Keys from the keyset on
    the Admin Portal. To associate a sender/current user with the PubNub messages, it's required to
-   configure the [`uuid`](https://www.pubnub.com/docs/setup/users-and-devices) parameter that stands
-   for Universally Unique Identifier and refers to your user ID in the database. If you wish, modify
+   configure [UUID](/docs/setup/users-and-devices) (the `userId` parameter) that stands for Universally Unique Identifier and refers to your user ID in the database. If you wish, modify
    the default value for the chat user.
 
 ```jsx
 publishKey: "myPublishKey",
 subscribeKey: "mySubscribeKey",
-uuid: "myFirstUser",
+userId: "myFirstUser",
 ```
 
 <details><summary style={{ cursor: "pointer" }}>More info</summary>
@@ -139,11 +138,11 @@ import { PubNubProvider } from "pubnub-react";
 import { Chat, MessageList, MessageInput } from "@pubnub/react-chat-components";
 
 /* Creates and configures your PubNub instance. Be sure to replace "myPublishKey" and "mySubscribeKey"
-  with your own keyset. If you wish, modify the default "myFirstUser" uuid value for the chat user. */
+  with your own keyset. If you wish, modify the default "myFirstUser" value for the chat user. */
 const pubnub = new PubNub({
   publishKey: "myPublishKey",
   subscribeKey: "mySubscribeKey",
-  uuid: "myFirstUser",
+  userId: "myFirstUser",
 });
 const currentChannel = "Default";
 const theme = "light";
@@ -195,11 +194,11 @@ import { PubNubProvider } from "pubnub-react";
 import { Chat, MessageList, MessageInput } from "@pubnub/react-chat-components";
 
 /* Creates and configures your PubNub instance. Be sure to replace "myPublishKey" and "mySubscribeKey"
-with your own keyset. If you wish, modify the default "myFirstUser" uuid value for the chat user. */
+with your own keyset. If you wish, modify the default "myFirstUser" value for the chat user. */
 const pubnub = new PubNub({
   publishKey: "myPublishKey",
   subscribeKey: "mySubscribeKey",
-  uuid: "myFirstUser",
+  userId: "myFirstUser",
 });
 const currentChannel = "Default";
 const theme = "light";

--- a/samples/getting-started/src/getting-started.tsx
+++ b/samples/getting-started/src/getting-started.tsx
@@ -6,11 +6,11 @@ import { PubNubProvider } from "pubnub-react";
 import { Chat, MessageList, MessageInput } from "@pubnub/react-chat-components";
 
 /* Creates and configures your PubNub instance. Be sure to replace "myPublishKey" and "mySubscribeKey"
-  with your own keyset. If you wish, modify the default "myFirstUser" uuid value for the chat user. */
+  with your own keyset. If you wish, modify the default "myFirstUser" value for the chat user. */
 const pubnub = new PubNub({
   publishKey: "myPublishKey",
   subscribeKey: "mySubscribeKey",
-  uuid: "myFirstUser",
+  userId: "myFirstUser",
 });
 const currentChannel = "Default";
 const theme = "light";


### PR DESCRIPTION
Most SDKs now use `userId` (name varied depending on the lg) instead of `uuid` in the step of PN object initialization. I've updated the Getting Started doc & app accordingly.

Related Jira ticket: https://pubnub.atlassian.net/browse/UI-1247.