### PR TITLE
fix(lib): fix infinite scrolling on MessageList not working when limi…

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -11,7 +11,7 @@ changelog:
     version: v0.15.0
     changes:
       - type: bug
-        text: "…t is set above 25 Story: https://pubnub.atlassian.net/browse/UI-1537."
+        text: "MessageList - infinite scrolling breaks if history limit is set over 25."
   - date: 2022-10-18
     version: v0.14.0
     changes:
@@ -42,12 +42,9 @@ changelog:
     version: v0.10.0
     changes:
       - type: fix
-        text:
-          "MessageInput - user metadata not attached to File messages with senderInfo option
-          enabled."
+        text: "MessageInput - user metadata not attached to File messages with senderInfo option enabled."
       - type: fix
-        text:
-          "Channel/MemberList - disable default flex shrinking of some UI elements (e.g. avatars)."
+        text: "Channel/MemberList - disable default flex shrinking of some UI elements (e.g. avatars)."
   - changes:
       - text: Channel/MemberList - added option for custom sorting
         type: feature

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,12 +1,17 @@
 ---
 name: pubnub-react-chat-components
-version: v0.14.0
+version: v0.15.0
 scm: github.com/pubnub/react-chat-components
 schema: 1
 files:
   - lib/dist/index.js
   - lib/dist/index.es.js
 changelog:
+  - date: 2022-11-09
+    version: v0.15.0
+    changes:
+      - type: bug
+        text: "…t is set above 25 Story: https://pubnub.atlassian.net/browse/UI-1537."
   - date: 2022-10-18
     version: v0.14.0
     changes:

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/common-chat-components",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/packages/common/src/message-list/message-list.tsx
+++ b/packages/common/src/message-list/message-list.tsx
@@ -46,7 +46,7 @@ export interface CommonMessageListProps {
   bubbleRenderer?: (props: MessageRendererProps) => JSX.Element;
   /** Option to provide a custom file renderer to change how images and other files are shown. */
   fileRenderer?: (file: FileAttachment) => JSX.Element;
-  /** Option to render only selected messages. */
+  /** This option only works when you use either `messageRenderer` or `bubbleRenderer`. It allows you to apply one of the custom renderers only to the messages selected by the filter. */
   filter?: (message: MessageEnvelope) => boolean;
 }
 

--- a/packages/common/src/message-list/message-list.tsx
+++ b/packages/common/src/message-list/message-list.tsx
@@ -7,6 +7,7 @@ import {
   MessageEnvelope,
   EmojiPickerElementProps,
   FileAttachment,
+  ProperFetchMessagesResponse,
 } from "../types";
 import { usePrevious } from "../helpers";
 import {
@@ -29,7 +30,7 @@ export interface MessageRendererProps {
 
 export interface CommonMessageListProps {
   children?: ReactNode;
-  /** Option to fetch past messages from storage and display them on a channel. Set a number from "0" to "100". Defaults to "0" to fetch no messages from storage. */
+  /** Set this option to a non-zero value to enable fetching messages from the History API. This feature uses the infinite scrolling pattern and takes a maximum value of 25. */
   fetchMessages?: number;
   /** Option to enable rendering reactions that were added to messages. Make sure to also set up reactionsPicker when this option is enabled. */
   enableReactions?: boolean;
@@ -131,7 +132,9 @@ export const useMessageListCore = (props: CommonMessageListProps) => {
         start: (messages?.[0]?.timetoken as number) || undefined,
         includeMessageActions: true,
       };
-      const response = await retry(() => pubnub.fetchMessages(options));
+      const response = (await retry(() =>
+        pubnub.fetchMessages(options)
+      )) as ProperFetchMessagesResponse;
       const newMessages = (response?.channels[channel] || []).map((m) =>
         m.messageType === 4 ? fetchFileUrl(m) : m
       ) as MessageEnvelope[];
@@ -139,7 +142,9 @@ export const useMessageListCore = (props: CommonMessageListProps) => {
         (a, b) => (a.timetoken as number) - (b.timetoken as number)
       );
       setMessages(allMessages);
-      setPaginationEnd(!allMessages.length || newMessages.length !== props.fetchMessages);
+      setPaginationEnd(
+        !response.more && (!allMessages.length || newMessages.length !== props.fetchMessages)
+      );
     } catch (e) {
       onError(e);
     } finally {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,4 +1,9 @@
-import { UUIDMetadataObject, ChannelMetadataObject, ObjectCustom } from "pubnub";
+import {
+  UUIDMetadataObject,
+  ChannelMetadataObject,
+  ObjectCustom,
+  FetchMessagesResponse,
+} from "pubnub";
 
 export type Themes = "light" | "dark" | "support" | "support-dark" | "event" | "event-dark";
 
@@ -82,4 +87,15 @@ export interface RetryOptions {
   maxRetries: number;
   timeout: number;
   exponentialFactor: number;
+}
+
+export interface ProperFetchMessagesResponse extends FetchMessagesResponse {
+  error: boolean;
+  error_message: string;
+  status: number;
+  more?: {
+    max: number;
+    start: string;
+    url: string;
+  };
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/react-native-chat-components",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "PubNub Chat Components is a development kit of React Native components that aims to help you to easily build Chat applications using PubNub infrastructure. It removes the complexicity of picking an adequate Chat engine, learning its APIs and dealing with its low-level internals. As the same time it allows you to create apps of various use cases, with different functionalities and customizable looks.",
   "author": "PubNub <support@pubnub.com>",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/react-chat-components",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "PubNub Chat Components is a development kit of React components that aims to help you to easily build Chat applications using PubNub infrastructure. It removes the complexicity of picking an adequate Chat engine, learning its APIs and dealing with its low-level internals. As the same time it allows you to create apps of various use cases, with different functionalities and customizable looks.",
   "author": "PubNub <support@pubnub.com>",
   "main": "dist/index.js",

--- a/packages/react/test/message-list.test.tsx
+++ b/packages/react/test/message-list.test.tsx
@@ -34,7 +34,7 @@ describe("Message List", () => {
     render(<MessageList welcomeMessages={message} />);
 
     expect(screen.getByText("Welcome")).toBeVisible();
-    expect(screen.getByText("11:25 AM")).toBeVisible();
+    expect(screen.getByText("11:25")).toBeVisible();
   });
 
   test("renders messages with custom message renderer", async () => {
@@ -52,7 +52,7 @@ describe("Message List", () => {
     );
 
     expect(screen.getByText("Custom Welcome")).toBeVisible();
-    expect(screen.queryByText("11:25 AM")).not.toBeInTheDocument();
+    expect(screen.queryByText("11:25")).not.toBeInTheDocument();
   });
 
   test("renders messages with custom bubble renderer", async () => {
@@ -70,7 +70,7 @@ describe("Message List", () => {
     );
 
     expect(screen.getByText("Custom Welcome")).toBeVisible();
-    expect(screen.getByText("11:25 AM")).toBeVisible();
+    expect(screen.getByText("11:25")).toBeVisible();
   });
 
   test("renders extra actions", async () => {

--- a/packages/react/test/message-list.test.tsx
+++ b/packages/react/test/message-list.test.tsx
@@ -34,7 +34,7 @@ describe("Message List", () => {
     render(<MessageList welcomeMessages={message} />);
 
     expect(screen.getByText("Welcome")).toBeVisible();
-    expect(screen.getByText("11:25")).toBeVisible();
+    expect(screen.getByText(/11:25/)).toBeVisible();
   });
 
   test("renders messages with custom message renderer", async () => {
@@ -52,7 +52,7 @@ describe("Message List", () => {
     );
 
     expect(screen.getByText("Custom Welcome")).toBeVisible();
-    expect(screen.queryByText("11:25")).not.toBeInTheDocument();
+    expect(screen.queryByText(/11:25/)).not.toBeInTheDocument();
   });
 
   test("renders messages with custom bubble renderer", async () => {
@@ -70,7 +70,7 @@ describe("Message List", () => {
     );
 
     expect(screen.getByText("Custom Welcome")).toBeVisible();
-    expect(screen.getByText("11:25")).toBeVisible();
+    expect(screen.getByText(/11:25/)).toBeVisible();
   });
 
   test("renders extra actions", async () => {

--- a/samples/react-native/mobile-chat/screens/chat.tsx
+++ b/samples/react-native/mobile-chat/screens/chat.tsx
@@ -16,7 +16,7 @@ export function ChatScreen(): JSX.Element {
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
         <MessageList
-          fetchMessages={20}
+          fetchMessages={25}
           // extraActionsRenderer={(msg) => <Button title="EA" onPress={() => console.log(msg)} />}
           // filter={(msg) => msg.message.text === "3"}
           // messageRenderer={(env) => <Text>{env.message.message.text}</Text>}

--- a/samples/react/group-chat/src/moderated-chat.tsx
+++ b/samples/react/group-chat/src/moderated-chat.tsx
@@ -299,7 +299,7 @@ export default function ModeratedChat(): JSX.Element {
               ) : (
                 <>
                   <MessageList
-                    fetchMessages={20}
+                    fetchMessages={25}
                     enableReactions={!isUserMuted}
                     reactionsPicker={
                       isUserMuted ? undefined : <Picker data={pickerData} theme={theme} />


### PR DESCRIPTION
fix: MessageList infinite scrolling breaks if history limit is set over 25

…t is set above 25
Story:
https://pubnub.atlassian.net/browse/UI-1537

Mentioned in 2 client issues:
https://pubnub.slack.com/archives/CCK0F2PGX/p1666913722140379?thread_ts=1632127730.204100&cid=CCK0F2PGX
https://pubnub.slack.com/archives/C03HQG4R91P/p1665777224184059

Server side "clarification":
https://pubnub.slack.com/archives/CFZEJH85P/p1666970675610129