### PR TITLE
feat(samples): changes for interactive telehealth demo

### DIFF
--- a/samples/react/telehealth/package.json
+++ b/samples/react/telehealth/package.json
@@ -13,6 +13,7 @@
     "@pubnub/react-chat-components": "*",
     "pubnub": "7.2.0",
     "pubnub-react": "3.0.1",
+    "pubnub-demo-integration": "1.0.0",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },

--- a/samples/react/telehealth/public/features.json
+++ b/samples/react/telehealth/public/features.json
@@ -1,0 +1,9 @@
+{
+    "features": [
+      "Log in as a Patient",
+      "Log in as a Doctor (in a new tab)",
+      "Send a Message as a Patient",
+      "Send a Message as a Doctor",
+      "Change the Application Theme"
+    ]
+  }

--- a/samples/react/telehealth/src/index.tsx
+++ b/samples/react/telehealth/src/index.tsx
@@ -25,7 +25,7 @@ function App(): JSX.Element {
           setDarkMode(!darkMode);
           actionCompleted({ action: "Change the Application Theme"});
         }}
-        className="absolute top-0 right-0 p-4 m-8 text-xs underline ease-in-out duration-300
+        className="absolute top-0 right-0 p-4 m-8 mt-2 text-xs underline ease-in-out duration-300
         text-slate-700 hover:text-slate-700"
       >
         {darkMode ? <SunIcon className="inline" /> : <MoonIcon className="inline" />}

--- a/samples/react/telehealth/src/index.tsx
+++ b/samples/react/telehealth/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 
 import { ReactComponent as MoonIcon } from "./assets/moon.svg";
 import { ReactComponent as SunIcon } from "./assets/sun.svg";
+import { actionCompleted } from "pubnub-demo-integration";
 import SwitchView from "./views/SwitchView";
 import "./index.css";
 
@@ -20,9 +21,12 @@ function App(): JSX.Element {
       } `}
     >
       <button
-        onClick={() => setDarkMode(!darkMode)}
-        className="absolute top-0 left-0 p-4 m-8 text-xs underline ease-in-out duration-300
-        text-cyan-700 hover:text-slate-700"
+        onClick={() => {
+          setDarkMode(!darkMode);
+          actionCompleted({ action: "Change the Application Theme"});
+        }}
+        className="absolute top-0 right-0 p-4 m-8 text-xs underline ease-in-out duration-300
+        text-slate-700 hover:text-slate-700"
       >
         {darkMode ? <SunIcon className="inline" /> : <MoonIcon className="inline" />}
         <span className="ml-2">Switch to {darkMode ? "Light" : "Dark"} Theme</span>

--- a/samples/react/telehealth/src/index.tsx
+++ b/samples/react/telehealth/src/index.tsx
@@ -23,7 +23,7 @@ function App(): JSX.Element {
       <button
         onClick={() => {
           setDarkMode(!darkMode);
-          actionCompleted({ action: "Change the Application Theme"});
+          actionCompleted({ action: "Change the Application Theme" });
         }}
         className="absolute top-0 right-0 p-4 m-8 mt-2 text-xs underline ease-in-out duration-300
         text-slate-700 hover:text-slate-700"

--- a/samples/react/telehealth/src/views/DoctorView.tsx
+++ b/samples/react/telehealth/src/views/DoctorView.tsx
@@ -91,7 +91,7 @@ function DoctorView(props: DoctorViewProps): JSX.Element {
               <MessageList 
                 welcomeMessages = {{
                 message: { id: "id-welcome-d", type: "welcome", text: "Please open another window or tab to chat" },
-                  timetoken: (new Date().getTime() * 10000) + "",
+                  timetoken: (new Date().getTime() * 10000).toString(),
                 }}
               />
               <MessageInput 

--- a/samples/react/telehealth/src/views/DoctorView.tsx
+++ b/samples/react/telehealth/src/views/DoctorView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   UserEntity,
   MessageList,
@@ -7,6 +7,7 @@ import {
   Chat,
   ChannelEntity,
 } from "@pubnub/react-chat-components";
+import { actionCompleted } from "pubnub-demo-integration";
 
 import { ReactComponent as MedicalIcon } from "../assets/clipboard-medical.svg";
 import { ReactComponent as ArrowUp } from "../assets/arrow-turn-up.svg";
@@ -20,7 +21,15 @@ type DoctorViewProps = {
 function DoctorView(props: DoctorViewProps): JSX.Element {
   const { doctor } = props;
   const doctorMemberships = memberships.filter((m) => m.members.includes(doctor.id));
-  const channels = doctorMemberships.reduce((acc: ChannelEntity[], m) => {
+  useEffect(() => {
+    if (window.innerHeight < 750)
+      setClasses("p-5 overflow-hidden h-[650px] w-[740px] flex flex-col")
+    else
+      setClasses("p-5 overflow-hidden h-[750px] w-[740px] flex flex-col")
+
+  }, []);
+    const [ classes, setClasses ] = useState("")
+    const channels = doctorMemberships.reduce((acc: ChannelEntity[], m) => {
     const patientId = m.members.find((id) => id !== doctor.id);
     const patient = users.find((u) => u.id === patientId);
     if (!patient) return acc;
@@ -41,7 +50,7 @@ function DoctorView(props: DoctorViewProps): JSX.Element {
   const [currentChannel, setCurrentChannel] = useState(channels[1] || { id: "default" });
 
   return (
-    <div className="p-5 overflow-hidden h-[750px] w-[740px] flex flex-col">
+    <div className={classes}>
       <header className="pb-2 mb-8 border-b border-solid border-gray-300">
         <h1 className="text-gray-400 font-bold">Doctor&apos;s Interface</h1>
         <h2 className="text-gray-400">
@@ -79,8 +88,18 @@ function DoctorView(props: DoctorViewProps): JSX.Element {
             </header>
 
             <article className="flex flex-col grow overflow-hidden">
-              <MessageList />
-              <MessageInput sendButton={<ArrowUp />} />
+              <MessageList 
+                welcomeMessages = {{
+                message: { id: "id-welcome-d", type: "welcome", text: "Please open another window or tab to chat" },
+                  timetoken: (new Date().getTime() * 10000) + "",
+                }}
+              />
+              <MessageInput 
+                sendButton={<ArrowUp />} 
+                onSend={(message) => {
+                  actionCompleted({ action: "Send a Message as a Doctor"});
+                }}
+              />
             </article>
           </section>
         </Chat>

--- a/samples/react/telehealth/src/views/DoctorView.tsx
+++ b/samples/react/telehealth/src/views/DoctorView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   UserEntity,
   MessageList,
@@ -21,15 +21,7 @@ type DoctorViewProps = {
 function DoctorView(props: DoctorViewProps): JSX.Element {
   const { doctor } = props;
   const doctorMemberships = memberships.filter((m) => m.members.includes(doctor.id));
-  useEffect(() => {
-    if (window.innerHeight < 750)
-      setClasses("p-5 overflow-hidden h-[650px] w-[740px] flex flex-col")
-    else
-      setClasses("p-5 overflow-hidden h-[750px] w-[740px] flex flex-col")
-
-  }, []);
-    const [ classes, setClasses ] = useState("")
-    const channels = doctorMemberships.reduce((acc: ChannelEntity[], m) => {
+  const channels = doctorMemberships.reduce((acc: ChannelEntity[], m) => {
     const patientId = m.members.find((id) => id !== doctor.id);
     const patient = users.find((u) => u.id === patientId);
     if (!patient) return acc;
@@ -50,7 +42,11 @@ function DoctorView(props: DoctorViewProps): JSX.Element {
   const [currentChannel, setCurrentChannel] = useState(channels[1] || { id: "default" });
 
   return (
-    <div className={classes}>
+    <div
+      className={`p-5 overflow-hidden w-[740px] flex flex-col ${
+        window.innerHeight < 750 ? "h-[650px]" : "h-[750px]"
+      }`}
+    >
       <header className="pb-2 mb-8 border-b border-solid border-gray-300">
         <h1 className="text-gray-400 font-bold">Doctor&apos;s Interface</h1>
         <h2 className="text-gray-400">
@@ -88,16 +84,20 @@ function DoctorView(props: DoctorViewProps): JSX.Element {
             </header>
 
             <article className="flex flex-col grow overflow-hidden">
-              <MessageList 
-                welcomeMessages = {{
-                message: { id: "id-welcome-d", type: "welcome", text: "Please open another window or tab to chat" },
+              <MessageList
+                welcomeMessages={{
+                  message: {
+                    id: "id-welcome-d",
+                    type: "welcome",
+                    text: "Please open another window or tab to chat",
+                  },
                   timetoken: (new Date().getTime() * 10000).toString(),
                 }}
               />
-              <MessageInput 
-                sendButton={<ArrowUp />} 
-                onSend={(message) => {
-                  actionCompleted({ action: "Send a Message as a Doctor"});
+              <MessageInput
+                sendButton={<ArrowUp />}
+                onSend={() => {
+                  actionCompleted({ action: "Send a Message as a Doctor" });
                 }}
               />
             </article>

--- a/samples/react/telehealth/src/views/LoginView.tsx
+++ b/samples/react/telehealth/src/views/LoginView.tsx
@@ -32,11 +32,13 @@ export default function LoginView(props: LoginViewProps): JSX.Element {
     await timeout(500);
     setLoading(false);
     const user = users.find((u) => u?.custom?.username === userInput);
-    user ? setUser(user) : setError(true);
-    if (user && user.type == "patient" )
-      actionCompleted({ action: "Log in as a Patient"});
-    else if (user && user.type == "doctor")
-      actionCompleted({ action: "Log in as a Doctor (in a new tab)"});
+    if (user) {
+      setUser(user);
+      actionCompleted({
+        action:
+          user.type === "patient" ? "Log in as a Patient" : "Log in as a Doctor (in a new tab)",
+      });
+    } else setError(true);
   };
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {

--- a/samples/react/telehealth/src/views/LoginView.tsx
+++ b/samples/react/telehealth/src/views/LoginView.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, FormEvent, useState } from "react";
 import { UserEntity } from "@pubnub/react-chat-components";
+import { actionCompleted } from "pubnub-demo-integration";
 
 import { ReactComponent as Logo } from "../assets/logo.svg";
 import { ReactComponent as LogoDark } from "../assets/logo-dark.svg";
@@ -32,6 +33,10 @@ export default function LoginView(props: LoginViewProps): JSX.Element {
     setLoading(false);
     const user = users.find((u) => u?.custom?.username === userInput);
     user ? setUser(user) : setError(true);
+    if (user && user.type == "patient" )
+      actionCompleted({ action: "Log in as a Patient"});
+    else if (user && user.type == "doctor")
+      actionCompleted({ action: "Log in as a Doctor (in a new tab)"});
   };
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {

--- a/samples/react/telehealth/src/views/PatientView.tsx
+++ b/samples/react/telehealth/src/views/PatientView.tsx
@@ -75,7 +75,7 @@ function PatientView(props: PatientViewProps): JSX.Element {
             <MessageList 
               welcomeMessages = {{
                 message: { id: "id-welcome-p", type: "welcome", text: "Please open another window or tab to chat" },
-                timetoken: (new Date().getTime() * 10000) + "",
+                timetoken: (new Date().getTime() * 10000).toString(),
               }}
             />
             <MessageInput 

--- a/samples/react/telehealth/src/views/PatientView.tsx
+++ b/samples/react/telehealth/src/views/PatientView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { UserEntity, MessageList, MessageInput, Chat } from "@pubnub/react-chat-components";
 import { actionCompleted } from "pubnub-demo-integration";
 
@@ -21,20 +21,14 @@ function PatientView(props: PatientViewProps): JSX.Element {
   const [widgetOpen, setWidgetOpen] = useState(true);
   const [unread, setUnread] = useState(0);
   const onMessage = () => setUnread((c) => c + 1);
-
-  useEffect(() => {
-    if (window.innerHeight < 750)
-      setClasses("patient-view flex flex-col items-end justify-end overflow-hidden p-5 h-[680px] w-[440px]")
-    else
-      setClasses("patient-view flex flex-col items-end justify-end overflow-hidden p-5 h-[750px] w-[440px]")
-
-  }, []);
-  const [ classes, setClasses ] = useState("")
-
   if (!channel || !doctor) return <></>;
 
   return (
-    <div className={classes}>
+    <div
+      className={`patient-view flex flex-col items-end justify-end overflow-hidden p-5 w-[440px] ${
+        window.innerHeight < 750 ? "h-[680px]" : "h-[750px]"
+      }`}
+    >
       <header className="pb-2 mb-8 border-b border-solid border-gray-300 w-full">
         <h1 className="text-gray-400 font-bold">Patient&apos;s Interface</h1>
         <h2 className="text-gray-400">
@@ -72,16 +66,20 @@ function PatientView(props: PatientViewProps): JSX.Element {
 
         <main className="flex flex-col overflow-hidden grow">
           <Chat currentChannel={channel} users={users} onMessage={onMessage}>
-            <MessageList 
-              welcomeMessages = {{
-                message: { id: "id-welcome-p", type: "welcome", text: "Please open another window or tab to chat" },
+            <MessageList
+              welcomeMessages={{
+                message: {
+                  id: "id-welcome-p",
+                  type: "welcome",
+                  text: "Please open another window or tab to chat",
+                },
                 timetoken: (new Date().getTime() * 10000).toString(),
               }}
             />
-            <MessageInput 
+            <MessageInput
               sendButton={<ArrowUpIcon />}
-              onSend={(message) => {
-                actionCompleted({ action: "Send a Message as a Patient"});
+              onSend={() => {
+                actionCompleted({ action: "Send a Message as a Patient" });
               }}
             />
           </Chat>

--- a/samples/react/telehealth/src/views/PatientView.tsx
+++ b/samples/react/telehealth/src/views/PatientView.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { UserEntity, MessageList, MessageInput, Chat } from "@pubnub/react-chat-components";
+import { actionCompleted } from "pubnub-demo-integration";
 
 import { ReactComponent as ArrowUpIcon } from "../assets/arrow-turn-up.svg";
 import { ReactComponent as UnderlineIcon } from "../assets/underline.svg";
@@ -21,10 +22,19 @@ function PatientView(props: PatientViewProps): JSX.Element {
   const [unread, setUnread] = useState(0);
   const onMessage = () => setUnread((c) => c + 1);
 
+  useEffect(() => {
+    if (window.innerHeight < 750)
+      setClasses("patient-view flex flex-col items-end justify-end overflow-hidden p-5 h-[680px] w-[440px]")
+    else
+      setClasses("patient-view flex flex-col items-end justify-end overflow-hidden p-5 h-[750px] w-[440px]")
+
+  }, []);
+  const [ classes, setClasses ] = useState("")
+
   if (!channel || !doctor) return <></>;
 
   return (
-    <div className="patient-view flex flex-col items-end justify-end overflow-hidden p-5 h-[750px] w-[440px]">
+    <div className={classes}>
       <header className="pb-2 mb-8 border-b border-solid border-gray-300 w-full">
         <h1 className="text-gray-400 font-bold">Patient&apos;s Interface</h1>
         <h2 className="text-gray-400">
@@ -62,8 +72,18 @@ function PatientView(props: PatientViewProps): JSX.Element {
 
         <main className="flex flex-col overflow-hidden grow">
           <Chat currentChannel={channel} users={users} onMessage={onMessage}>
-            <MessageList />
-            <MessageInput sendButton={<ArrowUpIcon />} />
+            <MessageList 
+              welcomeMessages = {{
+                message: { id: "id-welcome-p", type: "welcome", text: "Please open another window or tab to chat" },
+                timetoken: (new Date().getTime() * 10000) + "",
+              }}
+            />
+            <MessageInput 
+              sendButton={<ArrowUpIcon />}
+              onSend={(message) => {
+                actionCompleted({ action: "Send a Message as a Patient"});
+              }}
+            />
           </Chat>
         </main>
       </section>

--- a/samples/react/telehealth/src/views/SwitchView.tsx
+++ b/samples/react/telehealth/src/views/SwitchView.tsx
@@ -34,8 +34,8 @@ export default function SwitchView(props: { darkMode: boolean }): JSX.Element {
     <PubNubProvider client={pubnub}>
       <button
         onClick={() => setUser(undefined)}
-        className="absolute top-10 left-0 p-4 m-8 text-xs underline ease-in-out duration-300
-        text-cyan-700 hover:text-slate-700"
+        className="absolute top-10 right-0 p-4 m-4 mr-8 text-xs underline ease-in-out duration-300
+        text-slate-700 hover:text-slate-700"
       >
         <UnlockIcon className="inline" />
         <span className="ml-2">Log out</span>


### PR DESCRIPTION
These changes were made as part of DEVX-2371, update Telehealth demo to the interactive demo format.

This demo required more work than previous demos:
* Added interactivity with calls to actionCompleted();
* The demo itself did not fit within the bounds of the interactive demo iFrame.  The iFrame could not be enlarged without significant effort by the engineering team so I updated the app to reduce the height and shift the 'logout' / 'change theme' text to the right.  Since the UX of Telehealth was originally provided by the UX team, I ran these changes past Emma who has approved the changes.
* One review comment from the UX team during that review was that it wasn't obvious you needed to open the app in two different tabs / windows to chat.  I added a welcomeMessage to the MessageList component to make this clearer.