### PR TITLE
fix(lib): do not append duplicate messages to chat

### DIFF
--- a/packages/common/src/message-list/message-list.tsx
+++ b/packages/common/src/message-list/message-list.tsx
@@ -139,9 +139,9 @@ export const useMessageListCore = (props: CommonMessageListProps) => {
       const newMessages = (response?.channels[channel] || []).map((m) =>
         m.messageType === 4 ? fetchFileUrl(m) : m
       ) as MessageEnvelope[];
-      const allMessages = [...messages, ...newMessages].sort(
-        (a, b) => (a.timetoken as number) - (b.timetoken as number)
-      );
+      const allMessages = [...messages, ...newMessages]
+        .sort((a, b) => (a.timetoken as number) - (b.timetoken as number))
+        .filter((v, i, a) => a.findIndex((v2) => v2.uuid === v.uuid) === i);
       setMessages(allMessages);
       setPaginationEnd(
         !response.more && (!allMessages.length || newMessages.length !== props.fetchMessages)


### PR DESCRIPTION
Hello!

I noticed that when `fetchHistory` is set, it can show the most recently sent message twice. What's a good way to resolve this? 

I don't contribute to open source much, so let me know what else you need from me. 