### PR TITLE
fix(lib): fix custom metadata not being returned properly

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,12 +1,17 @@
 ---
 name: pubnub-react-chat-components
-version: v0.21.0
+version: v0.22.0
 scm: github.com/pubnub/react-chat-components
 schema: 1
 files:
   - lib/dist/index.js
   - lib/dist/index.es.js
 changelog:
+  - date: 2023-03-28
+    version: v0.22.0
+    changes:
+      - type: feature
+        text: "UseUserMemberships hook and useChannelMembers - make sure that both channel and user custom metadata fields are present in the hooks' responses."
   - date: 2023-03-27
     version: v0.21.0
     changes:

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/common-chat-components",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/packages/common/src/hooks/use-channel-members.ts
+++ b/packages/common/src/hooks/use-channel-members.ts
@@ -2,15 +2,15 @@ import { useState, useEffect, useMemo } from "react";
 import { GetChannelMembersParameters } from "pubnub";
 import { usePubNub } from "pubnub-react";
 import { merge, cloneDeep } from "lodash";
-import { UserChannelMembershipEntity } from "../types";
+import { UserEntityWithMembership } from "../types";
 
-type HookReturnValue = [UserChannelMembershipEntity[], () => void, () => void, number, Error];
+type HookReturnValue = [UserEntityWithMembership[], () => void, () => void, number, Error];
 
 export const useChannelMembers = (options: GetChannelMembersParameters): HookReturnValue => {
   const jsonOptions = JSON.stringify(options);
 
   const pubnub = usePubNub();
-  const [members, setMembers] = useState<UserChannelMembershipEntity[]>([]);
+  const [members, setMembers] = useState<UserEntityWithMembership[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState("");
   const [error, setError] = useState<Error>();
@@ -57,14 +57,14 @@ export const useChannelMembers = (options: GetChannelMembersParameters): HookRet
           ...(response.data.map((m) => {
             const returnObject = {
               ...m.uuid,
-            } as UserChannelMembershipEntity;
+            } as UserEntityWithMembership;
 
             if (m.custom) {
               returnObject.membership = m.custom;
             }
 
             return returnObject;
-          }) as UserChannelMembershipEntity[]),
+          }) as UserEntityWithMembership[]),
         ]);
         setTotalCount(response.totalCount);
         setPage(response.next);

--- a/packages/common/src/hooks/use-user-memberships.ts
+++ b/packages/common/src/hooks/use-user-memberships.ts
@@ -2,15 +2,15 @@ import { useState, useEffect, useMemo } from "react";
 import { GetMembershipsParametersv2 } from "pubnub";
 import { usePubNub } from "pubnub-react";
 import { merge, cloneDeep } from "lodash";
-import { UserChannelMembershipEntity } from "../types";
+import { ChannelEntityWithMembership } from "../types";
 
-type HookReturnValue = [UserChannelMembershipEntity[], () => void, () => void, number, Error];
+type HookReturnValue = [ChannelEntityWithMembership[], () => void, () => void, number, Error];
 
 export const useUserMemberships = (options: GetMembershipsParametersv2 = {}): HookReturnValue => {
   const jsonOptions = JSON.stringify(options);
 
   const pubnub = usePubNub();
-  const [channels, setChannels] = useState<UserChannelMembershipEntity[]>([]);
+  const [channels, setChannels] = useState<ChannelEntityWithMembership[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [page, setPage] = useState("");
   const [error, setError] = useState<Error>();
@@ -57,14 +57,14 @@ export const useUserMemberships = (options: GetMembershipsParametersv2 = {}): Ho
           ...(response.data.map((m) => {
             const returnObject = {
               ...m.channel,
-            } as UserChannelMembershipEntity;
+            } as ChannelEntityWithMembership;
 
             if (m.custom) {
               returnObject.membership = m.custom;
             }
 
             return returnObject;
-          }) as UserChannelMembershipEntity[]),
+          }) as ChannelEntityWithMembership[]),
         ]);
         setTotalCount(response.totalCount);
         setPage(response.next);

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -9,6 +9,10 @@ export type Themes = "light" | "dark" | "support" | "support-dark" | "event" | "
 
 export type ChannelEntity = ChannelMetadataObject<ObjectCustom>;
 
+export type UserChannelMembershipEntity = ChannelEntity & {
+  membership?: ObjectCustom;
+};
+
 export type UserEntity = UUIDMetadataObject<ObjectCustom>;
 
 export interface MessageEnvelope {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -9,11 +9,15 @@ export type Themes = "light" | "dark" | "support" | "support-dark" | "event" | "
 
 export type ChannelEntity = ChannelMetadataObject<ObjectCustom>;
 
-export type UserChannelMembershipEntity = ChannelEntity & {
+export type UserEntity = UUIDMetadataObject<ObjectCustom>;
+
+export type ChannelEntityWithMembership = ChannelEntity & {
   membership?: ObjectCustom;
 };
 
-export type UserEntity = UUIDMetadataObject<ObjectCustom>;
+export type UserEntityWithMembership = UserEntity & {
+  membership?: ObjectCustom;
+};
 
 export interface MessageEnvelope {
   channel?: string;

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/react-native-chat-components",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "PubNub Chat Components is a development kit of React Native components that aims to help you to easily build Chat applications using PubNub infrastructure. It removes the complexicity of picking an adequate Chat engine, learning its APIs and dealing with its low-level internals. As the same time it allows you to create apps of various use cases, with different functionalities and customizable looks.",
   "author": "PubNub <support@pubnub.com>",
   "main": "dist/commonjs/index",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/react-chat-components",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "PubNub Chat Components is a development kit of React components that aims to help you to easily build Chat applications using PubNub infrastructure. It removes the complexicity of picking an adequate Chat engine, learning its APIs and dealing with its low-level internals. As the same time it allows you to create apps of various use cases, with different functionalities and customizable looks.",
   "author": "PubNub <support@pubnub.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
feat: useUserMemberships hook and useChannelMembers - make sure that both channel and user custom metadata fields are present in the hooks' responses.