### PR TITLE
handle message deduplication

### DIFF
--- a/packages/common/src/chat/chat.tsx
+++ b/packages/common/src/chat/chat.tsx
@@ -195,7 +195,8 @@ export const ChatInternal: FC<ChatProps> = (props: ChatProps) => {
         setMessages((messages) => {
           const messagesClone = cloneDeep(messages) || {};
           messagesClone[message.channel] = messagesClone[message.channel] || [];
-          messagesClone[message.channel].push(message);
+          const hasMessage = messagesClone[message.channel].findIndex(m => m.timetoken === message.timetoken) > -1;
+          if (!hasMessage) messagesClone[message.channel].push(message);
           return messagesClone;
         });
 
@@ -298,7 +299,8 @@ export const ChatInternal: FC<ChatProps> = (props: ChatProps) => {
           const newMessage = { ...payload, message: { file, message }, messageType: 4 };
           const messagesClone = cloneDeep(messages) || {};
           messagesClone[newMessage.channel] = messagesClone[newMessage.channel] || [];
-          messagesClone[newMessage.channel].push(newMessage);
+          const hasMessage = messagesClone[message.channel].findIndex(m => m.timetoken === message.timetoken) > -1;
+          if (!hasMessage) messagesClone[message.channel].push(message);
           return messagesClone;
         });
 

--- a/packages/common/src/hooks/use-messages.ts
+++ b/packages/common/src/hooks/use-messages.ts
@@ -49,7 +49,8 @@ export const useMessages = (options: FetchMessagesParameters): HookReturnValue =
       setMessages((messages) => {
         const messagesClone = cloneDeep(messages);
         if (!messagesClone[message.channel]) messagesClone[message.channel] = [];
-        messagesClone[message.channel].push(message);
+        const hasMessage = messagesClone[message.channel].findIndex(m => m.timetoken === message.timetoken) > -1;
+        if (!hasMessage) messagesClone[message.channel].push(message);
         return messagesClone;
       });
     } catch (e) {


### PR DESCRIPTION
While working with the chat components on react native, we've run into some instances where published messages are duplicated in the message lists while messages are being fetched. A snippet of our RN code and a screenshot are below.

```jsx
import { Chat, MessageList } from '@pubnub/react-native-chat-components'

<View style={styles.channel}>
  <Chat
    currentChannel={currentChannel}
    retryOptions={pubnubChannelRetryOptions}
    onError={onErrorSendingMessage}
    users={currentChannelUsers}
  >
    <MessageList
      fetchMessages={25}
      messageRenderer={ChatBubble}
      style={{
        messageList: styles.messageList,
        messageListScroller: styles.messageListScroller,
        message: styles.message,
      }}
    />
  {/* ... code for our input component */}
  </Chat>
</View>
```

![IMG_074F72CB67F0-1](https://github.com/pubnub/react-chat-components/assets/5376222/18f19c3f-cd60-454e-84ff-451edb3ceee7)
