### PR TITLE
Update expo-file-system to be compatible with Expo SDK 51

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "expo-document-picker": "11.2.2",
-    "expo-file-system": "15.2.2",
+    "expo-file-system": "17.0.1",
     "expo-image-picker": "14.1.1",
     "expo-media-library": "15.2.3",
     "expo-sharing": "11.2.2",


### PR DESCRIPTION
The old expo-file-system will break SDK 51 builds.